### PR TITLE
always explicitly decode UTF-8

### DIFF
--- a/katello_certs_tools/katello_ssl_tool.py
+++ b/katello_certs_tools/katello_ssl_tool.py
@@ -183,7 +183,7 @@ ERROR: a CA private key already exists:
     finally:
         chdir(cwd)
 
-    out = out_stream.read().decode()
+    out = out_stream.read().decode('utf-8')
     out_stream.close()
     err = err_stream.read()
     err_stream.close()
@@ -269,7 +269,7 @@ def genPublicCaCert(password, d, verbosity=0, forceYN=0):
     finally:
         chdir(cwd)
 
-    out = out_stream.read().decode()
+    out = out_stream.read().decode('utf-8')
     out_stream.close()
     err = err_stream.read()
     err_stream.close()
@@ -329,7 +329,7 @@ def genServerKey(d, verbosity=0):
     finally:
         chdir(cwd)
 
-    out = out_stream.read().decode()
+    out = out_stream.read().decode('utf-8')
     out_stream.close()
     err = err_stream.read()
     err_stream.close()
@@ -407,7 +407,7 @@ def genServerCertReq(d, verbosity=0):
     finally:
         chdir(cwd)
 
-    out = out_stream.read().decode()
+    out = out_stream.read().decode('utf-8')
     out_stream.close()
     err = err_stream.read()
     err_stream.close()
@@ -514,7 +514,7 @@ def genServerCert(password, d, verbosity=0):
     finally:
         chdir(cwd)
 
-    out = out_stream.read().decode()
+    out = out_stream.read().decode('utf-8')
     out_stream.close()
     err = err_stream.read()
     err_stream.close()
@@ -662,7 +662,7 @@ Generating CA public certificate RPM:
     chdir(cwd)
     _reenableRpmMacros()
 
-    out = out_stream.read().decode()
+    out = out_stream.read().decode('utf-8')
     out_stream.close()
     err = err_stream.read()
     err_stream.close()
@@ -953,7 +953,7 @@ Generating web server's SSL key pair/set RPM:
         _reenableRpmMacros()
         os.unlink(postun_scriptlet)
 
-    out = out_stream.read().decode()
+    out = out_stream.read().decode('utf-8')
     out_stream.close()
     err = err_stream.read()
     err_stream.close()

--- a/katello_certs_tools/sslToolConfig.py
+++ b/katello_certs_tools/sslToolConfig.py
@@ -484,7 +484,7 @@ def figureSerial(caCertFilename, serialFilename, indexFilename):
     # what serial # is the ca cert using (we need to increment from that)
     ret, outstream, errstream = rhn_popen(['/usr/bin/openssl', 'x509', '-noout',
                                            '-serial', '-in', caCertFilename])
-    out = outstream.read().decode()
+    out = outstream.read().decode('utf-8')
     outstream.close()
     errstream.read()
     errstream.close()


### PR DESCRIPTION
otherwise decode() on Python2 will default to ASCII and thus we end up
with errors like this:

    ERROR: unhandled exception occurred:
    Traceback (most recent call last):
      File "/bin/katello-ssl-tool", line 51, in <module>
        sys.exit(mod.main() or 0)
      File "/usr/lib/python2.7/site-packages/katello_certs_tools/katello_ssl_tool.py", line 1102, in main
        ret = _main() or 0
      File "/usr/lib/python2.7/site-packages/katello_certs_tools/katello_ssl_tool.py", line 1050, in _main
        genCaRpm(DEFS, options.verbose)
      File "/usr/lib/python2.7/site-packages/katello_certs_tools/katello_ssl_tool.py", line 665, in genCaRpm
        out = out_stream.read().decode()
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 73: ordinal not in range(128)