### PR TITLE
hdrLabelCompare expects two rpm.hdr, not tuples or anything else

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,4 @@ install:
   - pip install flake8
 script:
   - flake8
-  - docbook2man katello-ssl-tool.sgml
-  - python setup.py install
   - .travis/test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 dist: xenial
+services:
+  - docker
 virtualenv:
   system_site_packages: true
 python:
@@ -17,3 +19,6 @@ install:
 script:
   - flake8
   - .travis/test.sh
+  # the git clean is required so that we don't leak the virtualenv inside the container
+  - git clean -dfx
+  - docker run -v $(pwd):/app --workdir=/app --rm centos:7 bash .travis/test.sh

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,13 +1,36 @@
-#!/bin/bash -e
+#!/bin/bash
+
+set -e
+
+export LC_ALL=en_US.UTF-8
+
+TEST_ON_EL=$([ -f /etc/redhat-release ] && [ -x /usr/bin/yum ] && echo "true" || echo "false")
+
+if [[ "${TEST_ON_EL}" == "true" ]]; then
+  yum install -y docbook-utils openssl rpm-build
+fi
+
+docbook2man katello-ssl-tool.sgml
+
+python setup.py install
 
 for i in `seq 1 4`; do
-katello-ssl-tool --gen-ca -p file:/etc/pki/katello/private/katello-default-ca.pwd --force --ca-cert-dir /etc/pki/katello-certs-tools/certs --set-common-name example.com --ca-cert katello-default-ca.crt --ca-key katello-default-ca.key --ca-cert-rpm katello-default-ca --set-country US --set-state "North Carolina" --set-city Raleigh --set-org Katello --set-org-unit SomeOrgUnit
+  katello-ssl-tool --gen-ca -p file:/etc/pki/katello/private/katello-default-ca.pwd --force --ca-cert-dir /etc/pki/katello-certs-tools/certs --set-common-name example.com --ca-cert katello-default-ca.crt --ca-key katello-default-ca.key --ca-cert-rpm katello-default-ca --set-country US --set-state "North Carolina" --set-city Raleigh --set-org Katello --set-org-unit SomeOrgUnit
+
+  if [[ "${TEST_ON_EL}" == "true" ]]; then
+    yum install -y $(ls -1t ./ssl-build/katello-default-ca-*.noarch.rpm|head -n1)
+  fi
+
 done
 
 for i in `seq 1 4`; do
-katello-ssl-tool --gen-server -p file:/etc/pki/katello/private/katello-default-ca.pwd --ca-cert-dir /etc/pki/katello-certs-tools/certs --set-common-name foo.example.com --ca-cert katello-default-ca.crt --ca-key katello-default-ca.key --set-country US --set-state "North Carolina" --set-city Raleigh --set-org Katello --set-org-unit SomeOrgUnit --cert-expiration 36500
+  katello-ssl-tool --gen-server -p file:/etc/pki/katello/private/katello-default-ca.pwd --ca-cert-dir /etc/pki/katello-certs-tools/certs --set-common-name foo.example.com --ca-cert katello-default-ca.crt --ca-key katello-default-ca.key --set-country US --set-state "North Carolina" --set-city Raleigh --set-org Katello --set-org-unit SomeOrgUnit --cert-expiration 36500
+
+  if [[ "${TEST_ON_EL}" == "true" ]]; then
+    yum install -y $(ls -1t ./ssl-build/$HOSTNAME/katello-httpd-ssl-key-pair-$HOSTNAME-*.noarch.rpm|head -n1)
+  fi
 done
 
 for i in `seq 1 4`; do
-katello-ssl-tool --gen-client -p file:/etc/pki/katello/private/katello-default-ca.pwd --ca-cert-dir /etc/pki/katello-certs-tools/certs --set-common-name foo.example.com --ca-cert katello-default-ca.crt --ca-key katello-default-ca.key --set-country US --set-state "North Carolina" --set-city Raleigh --set-org Katello --set-org-unit SomeOrgUnit --cert-expiration 36500
+  katello-ssl-tool --gen-client -p file:/etc/pki/katello/private/katello-default-ca.pwd --ca-cert-dir /etc/pki/katello-certs-tools/certs --set-common-name foo.example.com --ca-cert katello-default-ca.crt --ca-key katello-default-ca.key --set-country US --set-state "North Carolina" --set-city Raleigh --set-org Katello --set-org-unit SomeOrgUnit --cert-expiration 36500
 done

--- a/katello_certs_tools/rhn_rpm.py
+++ b/katello_certs_tools/rhn_rpm.py
@@ -306,15 +306,7 @@ def sortRPMs(rpms):
     """ Sorts a list of RPM files. They *must* exist.  """
 
     assert isinstance(rpms, type([]))
-
-    # Build a list of (header, rpm)
-    helper = list(map(lambda x: (get_package_header(x), x), rpms))
-
-    # Sort the list using the headers as a comparison
-    helper = sorted(helper, key=lambda x: hdrLabelCompareKey(x[0]))
-
-    # Extract the rpm names now
-    return list(map(lambda x: x[1], helper))
+    return sorted(rpms, key=lambda rpm: hdrLabelCompareKey(get_package_header(rpm)))
 
 
 def getInstalledHeader(rpmName):

--- a/katello_certs_tools/rhn_rpm.py
+++ b/katello_certs_tools/rhn_rpm.py
@@ -286,9 +286,6 @@ def nvre_compare(t1, t2):
 def hdrLabelCompare(hdr1, hdr2):
     """ take two RPMs or headers and compare them for order """
 
-    hdr1 = hdr1[0]
-    hdr2 = hdr2[0]
-
     if hdr1['name'] == hdr2['name']:
         hdr1 = [hdr1['epoch'], hdr1['version'].decode('utf-8'), hdr1['release'].decode('utf-8')]
         hdr2 = [hdr2['epoch'], hdr2['version'].decode('utf-8'), hdr2['release'].decode('utf-8')]
@@ -302,6 +299,9 @@ def hdrLabelCompare(hdr1, hdr2):
     return 1
 
 
+hdrLabelCompareKey = functools.cmp_to_key(hdrLabelCompare)
+
+
 def sortRPMs(rpms):
     """ Sorts a list of RPM files. They *must* exist.  """
 
@@ -311,7 +311,7 @@ def sortRPMs(rpms):
     helper = list(map(lambda x: (get_package_header(x), x), rpms))
 
     # Sort the list using the headers as a comparison
-    helper = sorted(helper, key=functools.cmp_to_key(hdrLabelCompare))
+    helper = sorted(helper, key=lambda x: hdrLabelCompareKey(x[0]))
 
     # Extract the rpm names now
     return list(map(lambda x: x[1], helper))


### PR DESCRIPTION
`sortRPMs` should only pass `rpm.hdr` to `hdrLabelCompare`, not tuples of `(rpm.hdr, path)` as they are in the `helper` list.

this also allows running tests inside a container, so we can actually reproduce the error.