### PR TITLE
Add the --ca-cert option to katello-ssl-tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+*.egg-info

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -14,23 +14,11 @@ docbook2man katello-ssl-tool.sgml
 
 python setup.py install
 
-for i in `seq 1 4`; do
-  katello-ssl-tool --gen-ca -p file:/etc/pki/katello/private/katello-default-ca.pwd --force --ca-cert-dir /etc/pki/katello-certs-tools/certs --set-common-name example.com --ca-cert katello-default-ca.crt --ca-key katello-default-ca.key --ca-cert-rpm katello-default-ca --set-country US --set-state "North Carolina" --set-city Raleigh --set-org Katello --set-org-unit SomeOrgUnit
-
-  if [[ "${TEST_ON_EL}" == "true" ]]; then
-    yum install -y $(ls -1t ./ssl-build/katello-default-ca-*.noarch.rpm|head -n1)
-  fi
-
-done
-
-for i in `seq 1 4`; do
-  katello-ssl-tool --gen-server -p file:/etc/pki/katello/private/katello-default-ca.pwd --ca-cert-dir /etc/pki/katello-certs-tools/certs --set-common-name foo.example.com --ca-cert katello-default-ca.crt --ca-key katello-default-ca.key --set-country US --set-state "North Carolina" --set-city Raleigh --set-org Katello --set-org-unit SomeOrgUnit --cert-expiration 36500
-
-  if [[ "${TEST_ON_EL}" == "true" ]]; then
-    yum install -y $(ls -1t ./ssl-build/$HOSTNAME/katello-httpd-ssl-key-pair-$HOSTNAME-*.noarch.rpm|head -n1)
-  fi
-done
-
-for i in `seq 1 4`; do
-  katello-ssl-tool --gen-client -p file:/etc/pki/katello/private/katello-default-ca.pwd --ca-cert-dir /etc/pki/katello-certs-tools/certs --set-common-name foo.example.com --ca-cert katello-default-ca.crt --ca-key katello-default-ca.key --set-country US --set-state "North Carolina" --set-city Raleigh --set-org Katello --set-org-unit SomeOrgUnit --cert-expiration 36500
+for filename in tests/* ; do
+	if [[ -x $filename ]] ; then
+		$filename
+	else
+		echo "File $filename is not executable"
+		exit 1
+	fi
 done

--- a/katello_certs_tools/sslToolCli.py
+++ b/katello_certs_tools/sslToolCli.py
@@ -175,7 +175,7 @@ def _getOptionsTree(defs):
         + _genOptions + [_optServerCertReqOnly]
     _serverCertOnlySet = [_optGenServer, _optGenClient] + _serverCertOptions \
         + _genOptions + [_optServerCertOnly]  # noqa: E501
-    _serverRpmOnlySet = [_optGenServer, _optGenClient, _optServerKey, _optServerCertReq, _optServerCert, _optServerCertDir, _optSetHostname, _optSetCname] \
+    _serverRpmOnlySet = [_optGenServer, _optGenClient, _optServerKey, _optServerCertReq, _optServerCert, _optCaCert, _optServerCertDir, _optSetHostname, _optSetCname] \
         + _buildRpmOptions + [_optServerRpm, _optServerTar] + _genOptions  # noqa: E501
 
     optionsTree = {

--- a/tests/custom-ca.sh
+++ b/tests/custom-ca.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+DIRECTORY=$(mktemp -d)
+trap "rm -rf $DIRECTORY" EXIT
+cd $DIRECTORY
+
+set -xe
+
+INSTALL_RPMS=$([ -f /etc/redhat-release ] && [ -x /usr/bin/yum ] && [[ $(id -u) == 0 ]] && echo "true" || echo "false")
+
+for i in `seq 1 4`; do
+  katello-ssl-tool --gen-ca -p file:/etc/pki/katello/private/katello-default-ca.pwd --force --ca-cert-dir /etc/pki/katello-certs-tools/certs --set-common-name example.com --ca-cert katello-default-ca.crt --ca-key katello-default-ca.key --ca-cert-rpm katello-default-ca --set-country US --set-state "North Carolina" --set-city Raleigh --set-org Katello --set-org-unit SomeOrgUnit
+
+  if [[ "${INSTALL_RPMS}" == "true" ]]; then
+    yum install -y $(ls -1t ./ssl-build/katello-default-ca-*.noarch.rpm|head -n1)
+  fi
+
+done
+
+test -e ssl-build/katello-default-ca-1.0-4.noarch.rpm
+
+for i in `seq 1 4`; do
+  katello-ssl-tool --gen-server -p file:/etc/pki/katello/private/katello-default-ca.pwd --ca-cert-dir /etc/pki/katello-certs-tools/certs --set-common-name foo.example.com --ca-cert katello-default-ca.crt --ca-key katello-default-ca.key --set-country US --set-state "North Carolina" --set-city Raleigh --set-org Katello --set-org-unit SomeOrgUnit --cert-expiration 36500
+
+  if [[ "${INSTALL_RPMS}" == "true" ]]; then
+    yum install -y $(ls -1t ./ssl-build/$HOSTNAME/katello-httpd-ssl-key-pair-$HOSTNAME-*.noarch.rpm|head -n1)
+  fi
+done
+
+test -e ssl-build/$HOSTNAME/katello-httpd-ssl-key-pair-$HOSTNAME-1.0-4.noarch.rpm
+
+for i in `seq 1 4`; do
+  katello-ssl-tool --gen-client -p file:/etc/pki/katello/private/katello-default-ca.pwd --ca-cert-dir /etc/pki/katello-certs-tools/certs --set-common-name foo.example.com --ca-cert katello-default-ca.crt --ca-key katello-default-ca.key --set-country US --set-state "North Carolina" --set-city Raleigh --set-org Katello --set-org-unit SomeOrgUnit --cert-expiration 36500
+done
+
+test -e ssl-build/$HOSTNAME/katello-httpd-ssl-key-pair-$HOSTNAME-1.0-8.noarch.rpm
+
+if [[ -x /usr/bin/tree ]] ; then
+	tree
+fi

--- a/tests/existing-certificate.sh
+++ b/tests/existing-certificate.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+HOSTNAME=host.example.com
+RPM=$HOSTNAME-apache
+CERT=cert.pem
+REQ=cert.req
+KEY=key.pem
+CA=KATELLO-TRUSTED-SSL-CERT
+
+DIRECTORY=$(mktemp -d)
+trap "rm -rf $DIRECTORY" EXIT
+cd $DIRECTORY
+
+set -ex
+
+mkdir -p ssl-build/$HOSTNAME
+touch ssl-build/$HOSTNAME/$CERT ssl-build/$HOSTNAME/$REQ ssl-build/$HOSTNAME/$KEY
+
+# Pretend we've generated a CA
+touch ssl-build/KATELLO-TRUSTED-SSL-CERT
+
+katello-ssl-tool --gen-server --set-hostname $HOSTNAME --server-cert $CERT --server-cert-req $REQ --server-key $KEY --server-rpm $RPM --rpm-only
+
+if [[ -x /usr/bin/tree ]] ; then
+	tree
+fi
+
+test -e ssl-build/$HOSTNAME/$RPM-1.0-1.src.rpm
+test -e ssl-build/$HOSTNAME/$RPM-1.0-1.noarch.rpm
+test -e ssl-build/$HOSTNAME/katello-httpd-ssl-archive-$HOSTNAME-1.0-1.tar
+
+TAR_CONTENTS=$(tar -taf ssl-build/$HOSTNAME/katello-httpd-ssl-archive-$HOSTNAME-1.0-1.tar)
+EXPECTED="$CA
+$HOSTNAME/$KEY
+$HOSTNAME/$CERT
+$HOSTNAME/$REQ"
+
+[[ $TAR_CONTENTS == $EXPECTED ]]

--- a/tests/existing-certificate.sh
+++ b/tests/existing-certificate.sh
@@ -5,7 +5,7 @@ RPM=$HOSTNAME-apache
 CERT=cert.pem
 REQ=cert.req
 KEY=key.pem
-CA=KATELLO-TRUSTED-SSL-CERT
+CA=ca.pem
 
 DIRECTORY=$(mktemp -d)
 trap "rm -rf $DIRECTORY" EXIT
@@ -14,12 +14,9 @@ cd $DIRECTORY
 set -ex
 
 mkdir -p ssl-build/$HOSTNAME
-touch ssl-build/$HOSTNAME/$CERT ssl-build/$HOSTNAME/$REQ ssl-build/$HOSTNAME/$KEY
+touch ssl-build/$HOSTNAME/$CERT ssl-build/$HOSTNAME/$REQ ssl-build/$HOSTNAME/$KEY ssl-build/$CA
 
-# Pretend we've generated a CA
-touch ssl-build/KATELLO-TRUSTED-SSL-CERT
-
-katello-ssl-tool --gen-server --set-hostname $HOSTNAME --server-cert $CERT --server-cert-req $REQ --server-key $KEY --server-rpm $RPM --rpm-only
+katello-ssl-tool --gen-server --set-hostname $HOSTNAME --server-cert $CERT --server-cert-req $REQ --server-key $KEY --ca-cert $CA --server-rpm $RPM --rpm-only
 
 if [[ -x /usr/bin/tree ]] ; then
 	tree


### PR DESCRIPTION
This option was implicitly already present since --help did document it and the value is actually used in the genProxyServerTarball function.