### PR TITLE
Stop generating a tarbal with certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+*.egg-info

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -14,23 +14,11 @@ docbook2man katello-ssl-tool.sgml
 
 python setup.py install
 
-for i in `seq 1 4`; do
-  katello-ssl-tool --gen-ca -p file:/etc/pki/katello/private/katello-default-ca.pwd --force --ca-cert-dir /etc/pki/katello-certs-tools/certs --set-common-name example.com --ca-cert katello-default-ca.crt --ca-key katello-default-ca.key --ca-cert-rpm katello-default-ca --set-country US --set-state "North Carolina" --set-city Raleigh --set-org Katello --set-org-unit SomeOrgUnit
-
-  if [[ "${TEST_ON_EL}" == "true" ]]; then
-    yum install -y $(ls -1t ./ssl-build/katello-default-ca-*.noarch.rpm|head -n1)
-  fi
-
-done
-
-for i in `seq 1 4`; do
-  katello-ssl-tool --gen-server -p file:/etc/pki/katello/private/katello-default-ca.pwd --ca-cert-dir /etc/pki/katello-certs-tools/certs --set-common-name foo.example.com --ca-cert katello-default-ca.crt --ca-key katello-default-ca.key --set-country US --set-state "North Carolina" --set-city Raleigh --set-org Katello --set-org-unit SomeOrgUnit --cert-expiration 36500
-
-  if [[ "${TEST_ON_EL}" == "true" ]]; then
-    yum install -y $(ls -1t ./ssl-build/$HOSTNAME/katello-httpd-ssl-key-pair-$HOSTNAME-*.noarch.rpm|head -n1)
-  fi
-done
-
-for i in `seq 1 4`; do
-  katello-ssl-tool --gen-client -p file:/etc/pki/katello/private/katello-default-ca.pwd --ca-cert-dir /etc/pki/katello-certs-tools/certs --set-common-name foo.example.com --ca-cert katello-default-ca.crt --ca-key katello-default-ca.key --set-country US --set-state "North Carolina" --set-city Raleigh --set-org Katello --set-org-unit SomeOrgUnit --cert-expiration 36500
+for filename in tests/* ; do
+	if [[ -x $filename ]] ; then
+		$filename
+	else
+		echo "File $filename is not executable"
+		exit 1
+	fi
 done

--- a/katello_certs_tools/katello_ssl_tool.py
+++ b/katello_certs_tools/katello_ssl_tool.py
@@ -969,16 +969,11 @@ Generating web server's SSL key pair/set RPM:
 
     os.chmod('%s.noarch.rpm' % serverRpmName, 0o600)
 
-    # generic the tarball necessary for RHN Proxy against hosted installations
-    tarballFilepath = genProxyServerTarball(d, version=ver, release=rel,
-                                            verbosity=verbosity)
-
     # write-out latest.txt information
     latest_txt = os.path.join(serverKeyPairDir, 'latest.txt')
     fo = open(latest_txt, 'w')
     fo.write('%s.noarch.rpm\n' % os.path.basename(serverRpmName))
     fo.write('%s.src.rpm\n' % os.path.basename(serverRpmName))
-    fo.write('%s\n' % os.path.basename(tarballFilepath))
     fo.close()
     os.chmod(latest_txt, 0o600)
 

--- a/tests/custom-ca.sh
+++ b/tests/custom-ca.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+DIRECTORY=$(mktemp -d)
+trap "rm -rf $DIRECTORY" EXIT
+cd $DIRECTORY
+
+set -xe
+
+INSTALL_RPMS=$([ -f /etc/redhat-release ] && [ -x /usr/bin/yum ] && [[ $(id -u) == 0 ]] && echo "true" || echo "false")
+
+for i in `seq 1 4`; do
+  katello-ssl-tool --gen-ca -p file:/etc/pki/katello/private/katello-default-ca.pwd --force --ca-cert-dir /etc/pki/katello-certs-tools/certs --set-common-name example.com --ca-cert katello-default-ca.crt --ca-key katello-default-ca.key --ca-cert-rpm katello-default-ca --set-country US --set-state "North Carolina" --set-city Raleigh --set-org Katello --set-org-unit SomeOrgUnit
+
+  if [[ "${INSTALL_RPMS}" == "true" ]]; then
+    yum install -y $(ls -1t ./ssl-build/katello-default-ca-*.noarch.rpm|head -n1)
+  fi
+
+done
+
+test -e ssl-build/katello-default-ca-1.0-4.noarch.rpm
+
+for i in `seq 1 4`; do
+  katello-ssl-tool --gen-server -p file:/etc/pki/katello/private/katello-default-ca.pwd --ca-cert-dir /etc/pki/katello-certs-tools/certs --set-common-name foo.example.com --ca-cert katello-default-ca.crt --ca-key katello-default-ca.key --set-country US --set-state "North Carolina" --set-city Raleigh --set-org Katello --set-org-unit SomeOrgUnit --cert-expiration 36500
+
+  if [[ "${INSTALL_RPMS}" == "true" ]]; then
+    yum install -y $(ls -1t ./ssl-build/$HOSTNAME/katello-httpd-ssl-key-pair-$HOSTNAME-*.noarch.rpm|head -n1)
+  fi
+done
+
+test -e ssl-build/$HOSTNAME/katello-httpd-ssl-key-pair-$HOSTNAME-1.0-4.noarch.rpm
+
+for i in `seq 1 4`; do
+  katello-ssl-tool --gen-client -p file:/etc/pki/katello/private/katello-default-ca.pwd --ca-cert-dir /etc/pki/katello-certs-tools/certs --set-common-name foo.example.com --ca-cert katello-default-ca.crt --ca-key katello-default-ca.key --set-country US --set-state "North Carolina" --set-city Raleigh --set-org Katello --set-org-unit SomeOrgUnit --cert-expiration 36500
+done
+
+test -e ssl-build/$HOSTNAME/katello-httpd-ssl-key-pair-$HOSTNAME-1.0-8.noarch.rpm
+
+if [[ -x /usr/bin/tree ]] ; then
+	tree
+fi

--- a/tests/existing-certificate.sh
+++ b/tests/existing-certificate.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+HOSTNAME=host.example.com
+RPM=$HOSTNAME-apache
+CERT=cert.pem
+REQ=cert.req
+KEY=key.pem
+CA=KATELLO-TRUSTED-SSL-CERT
+
+DIRECTORY=$(mktemp -d)
+trap "rm -rf $DIRECTORY" EXIT
+cd $DIRECTORY
+
+set -ex
+
+mkdir -p ssl-build/$HOSTNAME
+touch ssl-build/$HOSTNAME/$CERT ssl-build/$HOSTNAME/$REQ ssl-build/$HOSTNAME/$KEY
+
+# Pretend we've generated a CA
+touch ssl-build/KATELLO-TRUSTED-SSL-CERT
+
+katello-ssl-tool --gen-server --set-hostname $HOSTNAME --server-cert $CERT --server-cert-req $REQ --server-key $KEY --server-rpm $RPM --rpm-only
+
+if [[ -x /usr/bin/tree ]] ; then
+	tree
+fi
+
+test -e ssl-build/$HOSTNAME/$RPM-1.0-1.src.rpm
+test -e ssl-build/$HOSTNAME/$RPM-1.0-1.noarch.rpm
+test -e ssl-build/$HOSTNAME/katello-httpd-ssl-archive-$HOSTNAME-1.0-1.tar
+
+TAR_CONTENTS=$(tar -taf ssl-build/$HOSTNAME/katello-httpd-ssl-archive-$HOSTNAME-1.0-1.tar)
+EXPECTED="$CA
+$HOSTNAME/$KEY
+$HOSTNAME/$CERT
+$HOSTNAME/$REQ"
+
+[[ $TAR_CONTENTS == $EXPECTED ]]

--- a/tests/existing-certificate.sh
+++ b/tests/existing-certificate.sh
@@ -5,7 +5,6 @@ RPM=$HOSTNAME-apache
 CERT=cert.pem
 REQ=cert.req
 KEY=key.pem
-CA=KATELLO-TRUSTED-SSL-CERT
 
 DIRECTORY=$(mktemp -d)
 trap "rm -rf $DIRECTORY" EXIT
@@ -16,9 +15,6 @@ set -ex
 mkdir -p ssl-build/$HOSTNAME
 touch ssl-build/$HOSTNAME/$CERT ssl-build/$HOSTNAME/$REQ ssl-build/$HOSTNAME/$KEY
 
-# Pretend we've generated a CA
-touch ssl-build/KATELLO-TRUSTED-SSL-CERT
-
 katello-ssl-tool --gen-server --set-hostname $HOSTNAME --server-cert $CERT --server-cert-req $REQ --server-key $KEY --server-rpm $RPM --rpm-only
 
 if [[ -x /usr/bin/tree ]] ; then
@@ -27,12 +23,4 @@ fi
 
 test -e ssl-build/$HOSTNAME/$RPM-1.0-1.src.rpm
 test -e ssl-build/$HOSTNAME/$RPM-1.0-1.noarch.rpm
-test -e ssl-build/$HOSTNAME/katello-httpd-ssl-archive-$HOSTNAME-1.0-1.tar
-
-TAR_CONTENTS=$(tar -taf ssl-build/$HOSTNAME/katello-httpd-ssl-archive-$HOSTNAME-1.0-1.tar)
-EXPECTED="$CA
-$HOSTNAME/$KEY
-$HOSTNAME/$CERT
-$HOSTNAME/$REQ"
-
-[[ $TAR_CONTENTS == $EXPECTED ]]
+test ! -e ssl-build/$HOSTNAME/katello-httpd-ssl-archive-$HOSTNAME-1.0-1.tar


### PR DESCRIPTION
This tarball is not used within Katello and only the RPMs are relevant.

It includes https://github.com/Katello/katello-certs-tools/pull/15