### PR TITLE
Major cleanup

### DIFF
--- a/katello_certs_tools/katello_ssl_tool.py
+++ b/katello_certs_tools/katello_ssl_tool.py
@@ -453,8 +453,9 @@ def genServerCertReq(d, verbosity=0):
     os.chmod(server_cert_req, 0o600)
 
 
-def genServerCert_dependencies(password, d):
-    """ server cert generation and signing dependency check """
+
+def genServerCert(password, d, verbosity=0):
+    """ server cert generation and signing """
 
     passwordCheck(password)
 
@@ -463,34 +464,19 @@ def genServerCert_dependencies(password, d):
     gendir(serverKeyPairDir)
 
     ca_key = os.path.join(d['--dir'], os.path.basename(d['--ca-key']))
+    dependencyCheck(ca_key)
+
     ca_cert = os.path.join(d['--dir'], os.path.basename(d['--ca-cert']))
+    dependencyCheck(ca_cert)
 
     server_cert_req = os.path.join(serverKeyPairDir,
                                    os.path.basename(d['--server-cert-req']))
-    ca_openssl_cnf = os.path.join(d['--dir'], CA_OPENSSL_CNF_NAME)
-
-    dependencyCheck(ca_openssl_cnf)
-    dependencyCheck(ca_key)
-    dependencyCheck(ca_cert)
     dependencyCheck(server_cert_req)
 
-
-def genServerCert(password, d, verbosity=0):
-    """ server cert generation and signing """
-
-    serverKeyPairDir = os.path.join(d['--dir'],
-                                    d['--set-hostname'])
-
-    genServerCert_dependencies(password, d)
-
-    ca_key = os.path.join(d['--dir'], os.path.basename(d['--ca-key']))
-    ca_cert = os.path.join(d['--dir'], os.path.basename(d['--ca-cert']))
-
-    server_cert_req = os.path.join(serverKeyPairDir,
-                                   os.path.basename(d['--server-cert-req']))
     server_cert = os.path.join(serverKeyPairDir,
                                os.path.basename(d['--server-cert']))
     ca_openssl_cnf = os.path.join(d['--dir'], CA_OPENSSL_CNF_NAME)
+    dependencyCheck(ca_openssl_cnf)
 
     index_txt = os.path.join(d['--dir'], 'index.txt')
     serial = os.path.join(d['--dir'], 'serial')
@@ -887,7 +873,6 @@ def _main():
         elif getOption(options, 'cert_req_only'):
             genServerCertReq(DEFS, options.verbose)
         elif getOption(options, 'cert_only'):
-            genServerCert_dependencies(getCAPassword(options, confirmYN=0), DEFS)
             genServerCert(getCAPassword(options, confirmYN=0), DEFS, options.verbose)
         elif getOption(options, 'rpm_only'):
             genServerRpm(DEFS, options.verbose)

--- a/katello_certs_tools/katello_ssl_tool.py
+++ b/katello_certs_tools/katello_ssl_tool.py
@@ -380,7 +380,7 @@ def genServerKey(d, verbosity=0):
     os.chmod(server_key, 0o600)
 
 
-def genServerCertReq_dependencies(d):
+def genServerCertReq(d, verbosity=0):
     """ private server cert request generation """
 
     serverKeyPairDir = os.path.join(d['--dir'],
@@ -391,20 +391,10 @@ def genServerCertReq_dependencies(d):
                               os.path.basename(d['--server-key']))
     dependencyCheck(server_key)
 
-
-def genServerCertReq(d, verbosity=0):
-    """ private server cert request generation """
-
-    serverKeyPairDir = os.path.join(d['--dir'],
-                                    d['--set-hostname'])
-    server_key = os.path.join(serverKeyPairDir,
-                              os.path.basename(d['--server-key']))
     server_cert_req = os.path.join(serverKeyPairDir,
                                    os.path.basename(d['--server-cert-req']))
     server_openssl_cnf = os.path.join(serverKeyPairDir,
                                       SERVER_OPENSSL_CNF_NAME)
-
-    genServerCertReq_dependencies(d)
 
     # XXX: hmm.. should private_key, etc. be set for this before the write?
     #      either that you pull the key/certs from the files all together?
@@ -895,7 +885,6 @@ def _main():
         if getOption(options, 'key_only'):
             genServerKey(DEFS, options.verbose)
         elif getOption(options, 'cert_req_only'):
-            genServerCertReq_dependencies(DEFS)
             genServerCertReq(DEFS, options.verbose)
         elif getOption(options, 'cert_only'):
             genServerCert_dependencies(getCAPassword(options, confirmYN=0), DEFS)

--- a/katello_certs_tools/katello_ssl_tool.py
+++ b/katello_certs_tools/katello_ssl_tool.py
@@ -242,12 +242,19 @@ ERROR: a CA private key already exists:
     os.chmod(ca_key, 0o600)
 
 
-def genPublicCaCert_dependencies(password, d, forceYN=0):
+def genPublicCaCert(password, d, verbosity=0, forceYN=0):
     """ public CA certificate (client-side) generation """
 
+    passwordCheck(password)
+
     gendir(d['--dir'])
+
     ca_key = os.path.join(d['--dir'], os.path.basename(d['--ca-key']))
-    ca_cert = os.path.join(d['--dir'], os.path.basename(d['--ca-cert']))
+    dependencyCheck(ca_key)
+
+    ca_cert_name = os.path.basename(d['--ca-cert'])
+    ca_cert = os.path.join(d['--dir'], ca_cert_name)
+    ca_openssl_cnf = os.path.join(d['--dir'], CA_OPENSSL_CNF_NAME)
 
     if not forceYN and os.path.exists(ca_cert):
         sys.stderr.write("""\
@@ -256,21 +263,6 @@ ERROR: a CA public certificate already exists:
        If you wish to generate a new one, use the --force option.
 """ % ca_cert)
         sys.exit(errnoGeneralError)
-
-    dependencyCheck(ca_key)
-
-    passwordCheck(password)
-
-
-def genPublicCaCert(password, d, verbosity=0, forceYN=0):
-    """ public CA certificate (client-side) generation """
-
-    ca_key = os.path.join(d['--dir'], os.path.basename(d['--ca-key']))
-    ca_cert_name = os.path.basename(d['--ca-cert'])
-    ca_cert = os.path.join(d['--dir'], ca_cert_name)
-    ca_openssl_cnf = os.path.join(d['--dir'], CA_OPENSSL_CNF_NAME)
-
-    genPublicCaCert_dependencies(password, d, forceYN)
 
     configFile = ConfigFile(ca_openssl_cnf)
     if '--set-hostname' in d:
@@ -846,7 +838,6 @@ def _main():
             genPrivateCaKey(getCAPassword(options), DEFS,
                             options.verbose, options.force)
         elif getOption(options, 'cert_only'):
-            genPublicCaCert_dependencies(getCAPassword(options), DEFS, options.force)
             genPublicCaCert(getCAPassword(options), DEFS,
                             options.verbose, options.force)
         elif getOption(options, 'rpm_only'):

--- a/katello_certs_tools/katello_ssl_tool.py
+++ b/katello_certs_tools/katello_ssl_tool.py
@@ -720,8 +720,8 @@ Make the public CA certficate publically available:
     return '%s.noarch.rpm' % clientRpmName
 
 
-def genServerRpm_dependencies(d):
-    """ generates server's SSL key set RPM - dependencies check """
+def genServerRpm(d, verbosity=0):
+    """ generates server's SSL key set RPM """
 
     serverKeyPairDir = os.path.join(d['--dir'],
                                     d['--set-hostname'])
@@ -729,32 +729,15 @@ def genServerRpm_dependencies(d):
 
     server_key_name = os.path.basename(d['--server-key'])
     server_key = os.path.join(serverKeyPairDir, server_key_name)
-
-    server_cert_name = os.path.basename(d['--server-cert'])
-    server_cert = os.path.join(serverKeyPairDir, server_cert_name)
-
-    server_cert_req_name = os.path.basename(d['--server-cert-req'])
-    server_cert_req = os.path.join(serverKeyPairDir, server_cert_req_name)
-
     dependencyCheck(server_key)
-    dependencyCheck(server_cert)
-    dependencyCheck(server_cert_req)
-
-
-def genServerRpm(d, verbosity=0):
-    """ generates server's SSL key set RPM """
-
-    serverKeyPairDir = os.path.join(d['--dir'],
-                                    d['--set-hostname'])
-
-    server_key_name = os.path.basename(d['--server-key'])
-    server_key = os.path.join(serverKeyPairDir, server_key_name)
 
     server_cert_name = os.path.basename(d['--server-cert'])
     server_cert = os.path.join(serverKeyPairDir, server_cert_name)
+    dependencyCheck(server_cert)
 
     server_cert_req_name = os.path.basename(d['--server-cert-req'])
     server_cert_req = os.path.join(serverKeyPairDir, server_cert_req_name)
+    dependencyCheck(server_cert_req)
 
     server_rpm_name = os.path.basename(d['--server-rpm'])
     server_rpm = os.path.join(serverKeyPairDir, server_rpm_name)
@@ -762,8 +745,6 @@ def genServerRpm(d, verbosity=0):
     server_cert_dir = d['--server-cert-dir']
 
     postun_scriptlet = os.path.join(d['--dir'], 'postun.scriptlet')
-
-    genServerRpm_dependencies(d)
 
     if verbosity >= 0:
         sys.stderr.write("\n...working...\n")
@@ -920,7 +901,6 @@ def _main():
             genServerCert_dependencies(getCAPassword(options, confirmYN=0), DEFS)
             genServerCert(getCAPassword(options, confirmYN=0), DEFS, options.verbose)
         elif getOption(options, 'rpm_only'):
-            genServerRpm_dependencies(DEFS)
             genServerRpm(DEFS, options.verbose)
         else:
             genServer_dependencies(getCAPassword(options, confirmYN=0), DEFS)

--- a/katello_certs_tools/katello_ssl_tool.py
+++ b/katello_certs_tools/katello_ssl_tool.py
@@ -449,17 +449,14 @@ def genServerCertReq(d, verbosity=0):
 def genServerCert(password, d, verbosity=0):
     """ server cert generation and signing """
 
-    passwordCheck(password)
+    genServerCert_dependencies(password, d)
 
     serverKeyPairDir = os.path.join(d['--dir'],
                                     d['--set-hostname'])
     gendir(serverKeyPairDir)
 
     ca_key = os.path.join(d['--dir'], os.path.basename(d['--ca-key']))
-    dependencyCheck(ca_key)
-
     ca_cert = os.path.join(d['--dir'], os.path.basename(d['--ca-cert']))
-    dependencyCheck(ca_cert)
 
     server_cert_req = os.path.join(serverKeyPairDir,
                                    os.path.basename(d['--server-cert-req']))
@@ -812,7 +809,7 @@ Deploy the server's SSL key pair/set RPM:
     return "%s.noarch.rpm" % serverRpmName
 
 
-def genServer_dependencies(password, d):
+def genServerCert_dependencies(password, d):
     """ deps for the general --gen-server command.
         I.e., generation of server.{key,csr,crt}.
     """
@@ -860,10 +857,11 @@ def _main():
         elif getOption(options, 'rpm_only'):
             genServerRpm(DEFS, options.verbose)
         else:
-            genServer_dependencies(getCAPassword(options, confirmYN=0), DEFS)
+            ca_password = getCAPassword(options, confirmYN=0)
+            genServerCert_dependencies(ca_password, DEFS)
             genServerKey(DEFS, options.verbose)
             genServerCertReq(DEFS, options.verbose)
-            genServerCert(getCAPassword(options, confirmYN=0), DEFS, options.verbose)
+            genServerCert(ca_password, DEFS, options.verbose)
             if not getOption(options, 'no_rpm'):
                 genServerRpm(DEFS, options.verbose)
 

--- a/katello_certs_tools/katello_ssl_tool.py
+++ b/katello_certs_tools/katello_ssl_tool.py
@@ -102,6 +102,12 @@ def dependencyCheck(filename):
         raise FailedFileDependencyException(filename)
 
 
+def passwordCheck(password):
+    if password is None:
+        sys.stderr.write('ERROR: a CA password must be supplied.\n')
+        sys.exit(errnoGeneralError)
+
+
 def pathJoin(path, filename):
     filename = os.path.basename(filename)
     return os.path.join(path, filename)
@@ -253,9 +259,7 @@ ERROR: a CA public certificate already exists:
 
     dependencyCheck(ca_key)
 
-    if password is None:
-        sys.stderr.write('ERROR: a CA password must be supplied.\n')
-        sys.exit(errnoGeneralError)
+    passwordCheck(password)
 
 
 def genPublicCaCert(password, d, verbosity=0, forceYN=0):
@@ -452,9 +456,7 @@ def genServerCertReq(d, verbosity=0):
 def genServerCert_dependencies(password, d):
     """ server cert generation and signing dependency check """
 
-    if password is None:
-        sys.stderr.write('ERROR: a CA password must be supplied.\n')
-        sys.exit(errnoGeneralError)
+    passwordCheck(password)
 
     serverKeyPairDir = os.path.join(d['--dir'],
                                     d['--set-hostname'])
@@ -852,9 +854,7 @@ def genServer_dependencies(password, d):
     dependencyCheck(ca_key)
     dependencyCheck(ca_cert)
 
-    if password is None:
-        sys.stderr.write('ERROR: a CA password must be supplied.\n')
-        sys.exit(errnoGeneralError)
+    passwordCheck(password)
 
 
 def _main():

--- a/katello_certs_tools/katello_ssl_tool.py
+++ b/katello_certs_tools/katello_ssl_tool.py
@@ -584,25 +584,18 @@ def _reenableRpmMacros():
         os.rename(macTmp, mac)
 
 
-def genCaRpm_dependencies(d):
-    """ generates ssl cert RPM. """
-
-    gendir(d['--dir'])
-    ca_cert_name = os.path.basename(d['--ca-cert'])
-    ca_cert = os.path.join(d['--dir'], ca_cert_name)
-    dependencyCheck(ca_cert)
-
-
 def genCaRpm(d, verbosity=0):
     """ generates ssl cert RPM. """
 
     ca_cert_path = d['--ca-cert-dir']
     ca_cert_name = os.path.basename(d['--ca-cert'])
     ca_cert = os.path.join(d['--dir'], ca_cert_name)
+    gendir(d['--dir'])
+    dependencyCheck(ca_cert)
+
     ca_cert_rpm_name = os.path.basename(d['--ca-cert-rpm'])
     ca_cert_rpm = os.path.join(d['--dir'], ca_cert_rpm_name)
 
-    genCaRpm_dependencies(d)
     appendOtherCACerts(d, ca_cert)
 
     if verbosity >= 0:
@@ -857,7 +850,6 @@ def _main():
             genPublicCaCert(getCAPassword(options), DEFS,
                             options.verbose, options.force)
         elif getOption(options, 'rpm_only'):
-            genCaRpm_dependencies(DEFS)
             genCaRpm(DEFS, options.verbose)
         else:
             genPrivateCaKey(getCAPassword(options), DEFS,

--- a/katello_certs_tools/katello_ssl_tool.py
+++ b/katello_certs_tools/katello_ssl_tool.py
@@ -60,30 +60,37 @@ from katello_certs_tools.sslToolConfig import ConfigFile, figureSerial, getOptio
 
 class GenPrivateCaKeyException(KatelloSslToolException):
     """ private CA key generation error """
+    code = 10
 
 
 class GenPublicCaCertException(KatelloSslToolException):
     """ public CA cert generation error """
+    code = 11
 
 
 class GenServerKeyException(KatelloSslToolException):
     """ private server key generation error """
+    code = 20
 
 
 class GenServerCertReqException(KatelloSslToolException):
     """ server cert request generation error """
+    code = 21
 
 
 class GenServerCertException(KatelloSslToolException):
     """ server cert generation error """
+    code = 22
 
 
 class GenCaCertRpmException(KatelloSslToolException):
     """ CA public certificate RPM generation error """
+    code = 12
 
 
 class GenServerRpmException(KatelloSslToolException):
     """ server RPM generation error """
+    code = 23
 
 
 class FailedFileDependencyException(Exception):
@@ -948,57 +955,21 @@ def main():
         100  general RHN SSL tool error
     """
 
-    def writeError(e):
-        sys.stderr.write('\nERROR: %s\n' % e)
-
     try:
         _main()
         ret = 0
-    # CA key set errors
-    except GenPrivateCaKeyException as e:
-        writeError(e)
-        ret = 10
-    except GenPublicCaCertException as e:
-        writeError(e)
-        ret = 11
-    except GenCaCertRpmException as e:
-        writeError(e)
-        ret = 12
-    # server key set errors
-    except GenServerKeyException as e:
-        writeError(e)
-        ret = 20
-    except GenServerCertReqException as e:
-        writeError(e)
-        ret = 21
-    except GenServerCertException as e:
-        writeError(e)
-        ret = 22
-    except GenServerRpmException as e:
-        writeError(e)
-        ret = 23
-    # other errors
-    except CertExpTooShortException as e:
-        writeError(e)
-        ret = 30
-    except CertExpTooLongException as e:
-        writeError(e)
-        ret = 31
-    except InvalidCountryCodeException as e:
-        writeError(e)
-        ret = 32
     except FailedFileDependencyException as e:
         # already wrote a nice error message
-        msg = """\
-can't find a file that should have been created during an earlier step:
+        msg = """
+ERROR: can't find a file that should have been created during an earlier step:
        %s
 
        %s --help""" % (e, os.path.basename(sys.argv[0]))
-        writeError(msg)
+        sys.stderr.write(msg)
         ret = 33
     except KatelloSslToolException as e:
-        writeError(e)
-        ret = 100
+        sys.stderr.write('\nERROR: %s\n' % e)
+        ret = e.code
     except KeyboardInterrupt:
         sys.stderr.write("\nUser interrupted process.\n")
         ret = 0

--- a/katello_certs_tools/sslToolCli.py
+++ b/katello_certs_tools/sslToolCli.py
@@ -353,14 +353,17 @@ def optionParse():
 
 class CertExpTooShortException(KatelloSslToolException):
     "certificate expiration must be at least 1 day"
+    code = 30
 
 
 class CertExpTooLongException(KatelloSslToolException):
     "cert expiration cannot be > 1 year before the 32-bit overflow (in days)"
+    code = 31
 
 
 class InvalidCountryCodeException(KatelloSslToolException):
     "invalid country code. Probably != 2 characters in length."
+    code = 32
 
 
 def processCommandline():

--- a/katello_certs_tools/sslToolLib.py
+++ b/katello_certs_tools/sslToolLib.py
@@ -28,6 +28,7 @@ from katello_certs_tools.timeLib import DAY, now, secs2days, secs2years
 
 class KatelloSslToolException(Exception):
     """ general exception class for the tool """
+    code = 100
 
 
 errnoGeneralError = 1


### PR DESCRIPTION
This PR aims to remove a lot of unused code or rewrite methods to an equivalent but easier implementation. There should be no difference for the end user.

6b4c116 Close file descriptors when possible
5b051f7 Implement katello-ssl-tool via console_scripts
0966426 Simplify value assignment
9f047a7 Drop unique and setIntersection functions
428d38d Remove unused functions
a4be37b Rewrite RPM version comparison code
f082f49 Remove checksum.py by checking file contents