### PR TITLE
Remove incSerial

### DIFF
--- a/katello_certs_tools/sslToolConfig.py
+++ b/katello_certs_tools/sslToolConfig.py
@@ -27,7 +27,7 @@ import socket
 
 # local imports
 from katello_certs_tools.fileutils import cleanupNormPath, rotateFile, rhn_popen, cleanupAbsPath
-from katello_certs_tools.sslToolLib import daysTil18Jan2038, incSerial, fixSerial
+from katello_certs_tools.sslToolLib import daysTil18Jan2038, fixSerial
 
 
 # defaults where we can see them (NOTE: directory is figured at write time)
@@ -502,8 +502,7 @@ def figureSerial(caCertFilename, serialFilename, indexFilename):
     # REMEMBER: openssl will incremented the serial number each time
     # as well.
     if serial <= caSerial:
-        serial = incSerial(hex(caSerial))
-        serial = int('0x' + serial, 16)
+        serial = caSerial + 1
     serial = fixSerial(hex(serial))
 
     # create the serial file if it doesn't exist

--- a/katello_certs_tools/sslToolLib.py
+++ b/katello_certs_tools/sslToolLib.py
@@ -58,25 +58,6 @@ def fixSerial(serial):
     return serial
 
 
-def incSerial(serial):
-    """ increment a serial hex number """
-
-    if not serial:
-        serial = '00'
-
-    if serial.find('0x') == -1:
-        serial = '0x'+serial
-
-    # the string might have a trailing L
-    serial = serial.replace('L', '')
-
-    serial = int(serial, 16) + 1
-    serial = hex(serial)
-
-    serial = serial.split('x')[-1]
-    return fixSerial(serial)
-
-
 #
 # NOTE: the Unix epoch overflows at: 2038-01-19 03:14:07 (2^31 seconds)
 #


### PR DESCRIPTION
This method effectively does int(hex(n), 16) + 1 with additional safeguards. However, since n is already an int, it's entirely redundant and it can be simplified to n = n + 1.