### PR TITLE
don't fail decoding data from RPM

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,9 +36,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        centos: ["7", "8"]
+        centos: ["7", "stream8"]
     container:
-      image: centos:${{ matrix.centos }}
+      image: quay.io/centos/centos:${{ matrix.centos }}
     steps:
       - uses: actions/checkout@v2
       - name: Run tests

--- a/katello_certs_tools/katello_ssl_tool.py
+++ b/katello_certs_tools/katello_ssl_tool.py
@@ -611,8 +611,12 @@ def genCaRpm(d, verbosity=0):
 
     ver, rel = '1.0', '0'
     if hdr is not None:
-        ver = str(hdr['version'].decode('utf-8'))
-        rel = str(hdr['release'].decode('utf-8'))
+        try:
+            ver = str(hdr['version'].decode('utf-8'))
+            rel = str(hdr['release'].decode('utf-8'))
+        except AttributeError:
+            ver = str(hdr['version'])
+            rel = str(hdr['release'])
 
     # bump the release - and let's not be too smart about it
     #                    assume the release is a number.
@@ -759,8 +763,12 @@ def genServerRpm(d, verbosity=0):
 
     ver, rel = '1.0', '0'
     if hdr is not None:
-        ver = str(hdr['version'].decode('utf-8'))
-        rel = str(hdr['release'].decode('utf-8'))
+        try:
+            ver = str(hdr['version'].decode('utf-8'))
+            rel = str(hdr['release'].decode('utf-8'))
+        except AttributeError:
+            ver = str(hdr['version'])
+            rel = str(hdr['release'])
 
     # bump the release - and let's not be too smart about it
     #                    assume the release is a number.

--- a/katello_certs_tools/rhn_rpm.py
+++ b/katello_certs_tools/rhn_rpm.py
@@ -73,14 +73,6 @@ class RPM_Header:
         else:
             return False
 
-    def checksum_type(self):
-        if self.hdr[rpm.RPMTAG_FILEDIGESTALGO] \
-           and int(self.hdr[rpm.RPMTAG_FILEDIGESTALGO]) in PGPHASHALGO:
-            checksum_type = PGPHASHALGO[int(self.hdr[rpm.RPMTAG_FILEDIGESTALGO])]
-        else:
-            checksum_type = 'md5'
-        return checksum_type
-
     def is_signed(self):
         if hasattr(rpm, "RPMTAG_DSAHEADER"):
             dsaheader = self.hdr["dsaheader"]

--- a/katello_certs_tools/rhn_rpm.py
+++ b/katello_certs_tools/rhn_rpm.py
@@ -75,8 +75,8 @@ class RPM_Header:
 
     def checksum_type(self):
         if self.hdr[rpm.RPMTAG_FILEDIGESTALGO] \
-           and self.hdr[rpm.RPMTAG_FILEDIGESTALGO].decode('utf-8') in PGPHASHALGO:
-            checksum_type = PGPHASHALGO[self.hdr[rpm.RPMTAG_FILEDIGESTALGO]]
+           and int(self.hdr[rpm.RPMTAG_FILEDIGESTALGO]) in PGPHASHALGO:
+            checksum_type = PGPHASHALGO[int(self.hdr[rpm.RPMTAG_FILEDIGESTALGO])]
         else:
             checksum_type = 'md5'
         return checksum_type
@@ -178,8 +178,12 @@ def hdrLabelCompare(hdr1, hdr2):
     """ take two RPMs or headers and compare them for order """
 
     if hdr1['name'] == hdr2['name']:
-        hdr1 = [hdr1['epoch'], hdr1['version'].decode('utf-8'), hdr1['release'].decode('utf-8')]
-        hdr2 = [hdr2['epoch'], hdr2['version'].decode('utf-8'), hdr2['release'].decode('utf-8')]
+        try:
+            hdr1 = [hdr1['epoch'], hdr1['version'].decode('utf-8'), hdr1['release'].decode('utf-8')]
+            hdr2 = [hdr2['epoch'], hdr2['version'].decode('utf-8'), hdr2['release'].decode('utf-8')]
+        except AttributeError:
+            hdr1 = [hdr1['epoch'], hdr1['version'], hdr1['release']]
+            hdr2 = [hdr2['epoch'], hdr2['version'], hdr2['release']]
         if hdr1[0]:
             hdr1[0] = str(hdr1[0])
         if hdr2[0]:


### PR DESCRIPTION
some versions of the RPM bindings will return strings, some bytes, some
unicode… And only some of these know decode().
So let's just catch that AttributeError and assume there is nothing to
decode if it's raised.

Fixes running certs tools on EL 8.5+ which got a "fixed" RPM.
See https://bugzilla.redhat.com/1840142 for some background.