### PR TITLE
Revert "Switch from genrsa to genpkey"

### DIFF
--- a/katello_certs_tools/katello_ssl_tool.py
+++ b/katello_certs_tools/katello_ssl_tool.py
@@ -189,8 +189,8 @@ ERROR: a CA private key already exists:
 """ % ca_key)
         sys.exit(errnoGeneralError)
 
-    args = ("/usr/bin/openssl genpkey -pass pass:%s %s -out %s -algorithm rsa -pkeyopt rsa_keygen_bits:4096"
-                % ('%s', CRYPTO, repr(cleanupAbsPath(ca_key))))
+    args = ("/usr/bin/openssl genrsa -passout pass:%s %s -out %s 4096"
+            % ('%s', CRYPTO, repr(cleanupAbsPath(ca_key))))
 
     if verbosity >= 0:
         print("Generating private CA key: %s" % ca_key)
@@ -332,8 +332,8 @@ def genServerKey(d, verbosity=0):
     server_key = os.path.join(serverKeyPairDir,
                               os.path.basename(d['--server-key']))
 
-    args = ("/usr/bin/openssl genpkey -out %s -algorithm rsa -pkeyopt rsa_keygen_bits:4096"
-                % (repr(cleanupAbsPath(server_key))))
+    args = ("/usr/bin/openssl genrsa -out %s 4096"
+            % (repr(cleanupAbsPath(server_key))))
 
     # generate the server key
     if verbosity >= 0:


### PR DESCRIPTION
This reverts commit 363f0e118c2b4b672f1ae8bcd3a08f0d0a0c72e5.

I left the CRYPTO change in sslToolConfig.py in, as it doesn't seem to
break anything.

Fixes: #41 