### PR TITLE
Fixes #34604 - Revert "Revert "Switch from genrsa to genpkey""

### DIFF
--- a/katello_certs_tools/katello_ssl_tool.py
+++ b/katello_certs_tools/katello_ssl_tool.py
@@ -189,8 +189,8 @@ ERROR: a CA private key already exists:
 """ % ca_key)
         sys.exit(errnoGeneralError)
 
-    args = ("/usr/bin/openssl genrsa -passout pass:%s %s -out %s 4096"
-            % ('%s', CRYPTO, repr(cleanupAbsPath(ca_key))))
+    args = ("/usr/bin/openssl genpkey -pass pass:%s %s -out %s -algorithm rsa -pkeyopt rsa_keygen_bits:4096"
+                % ('%s', CRYPTO, repr(cleanupAbsPath(ca_key))))
 
     if verbosity >= 0:
         print("Generating private CA key: %s" % ca_key)
@@ -332,8 +332,8 @@ def genServerKey(d, verbosity=0):
     server_key = os.path.join(serverKeyPairDir,
                               os.path.basename(d['--server-key']))
 
-    args = ("/usr/bin/openssl genrsa -out %s 4096"
-            % (repr(cleanupAbsPath(server_key))))
+    args = ("/usr/bin/openssl genpkey -out %s -algorithm rsa -pkeyopt rsa_keygen_bits:4096"
+                % (repr(cleanupAbsPath(server_key))))
 
     # generate the server key
     if verbosity >= 0:


### PR DESCRIPTION
This reverts commit e17529ebfc0590ff6140ab33bc19f67b95e8cbaa.

We originally reverted this to quickly fix issues with Candlepin accepting an encrypted CA key. The core solution has been implmented: https://github.com/theforeman/puppet-katello/commit/5945f26b8015cb98776492bf96a0a786e99ff7e8

We can now safely implement this change from deprecated genrsa to genpkey. This additionally allows operation of key-cert generation on a FIPS enabled EL 8+ machine.