### PR TITLE
Make it possible to run `katello-ssl-tool` concurrently for different hosts

### DIFF
--- a/katello_certs_tools/katello_ssl_tool.py
+++ b/katello_certs_tools/katello_ssl_tool.py
@@ -754,7 +754,7 @@ def genServerRpm(d, verbosity=0):
 
     server_cert_dir = d['--server-cert-dir']
 
-    postun_scriptlet = os.path.join(d['--dir'], 'postun.scriptlet')
+    postun_scriptlet = os.path.join(d['--dir'], d['--set-hostname'], 'postun.scriptlet')
 
     genServerRpm_dependencies(d)
 


### PR DESCRIPTION
The use of a postrun script file in a "shared" location made it impossible before this fix.

```
Traceback (most recent call last):
File "/bin/katello-ssl-tool", line 11, in <module>
load_entry_point('Katello-Certs-Tools==2.9.0', 'console_scripts', 'katello-ssl-tool')()
File "/usr/lib/python3.6/site-packages/katello_certs_tools/katello_ssl_tool.py", line 955, in main
_main()
File "/usr/lib/python3.6/site-packages/katello_certs_tools/katello_ssl_tool.py", line 924, in _main
genServerRpm(DEFS, options.verbose)
File "/usr/lib/python3.6/site-packages/katello_certs_tools/katello_ssl_tool.py", line 828, in genServerRpm
os.unlink(postun_scriptlet)
FileNotFoundError: [Errno 2] No such file or directory: '/root/ssl-build/postun.scriptlet'
```

- Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2265385 // https://issues.redhat.com/browse/SAT-23481