### PR TITLE
Cleanup deprecations and fix client/server usage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,10 +39,23 @@ jobs:
       fail-fast: false
       matrix:
         centos:
-          - stream8
           - stream9
     container:
       image: quay.io/centos/centos:${{ matrix.centos }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run tests
+        run: ./test.sh
+
+  almalinux:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        almalinux:
+          - 8
+    container:
+      image: almalinux:${{ matrix.almalinux }}
     steps:
       - uses: actions/checkout@v2
       - name: Run tests

--- a/katello-certs-sign
+++ b/katello-certs-sign
@@ -149,7 +149,6 @@ emailAddress		= optional
 [ usr_cert ]
 basicConstraints = CA:false
 extendedKeyUsage = serverAuth,clientAuth
-nsCertType = server
 keyUsage = digitalSignature, keyEncipherment
 
 # PKIX recommendations harmless if included in all certificates.

--- a/katello_certs_tools/sslToolConfig.py
+++ b/katello_certs_tools/sslToolConfig.py
@@ -375,14 +375,14 @@ authorityKeyIdentifier  = keyid, issuer:always
 [ req_server_x509_extensions ]
 basicConstraints = CA:false
 keyUsage = digitalSignature, keyEncipherment
-extendedKeyUsage = serverAuth, clientAuth
+extendedKeyUsage = serverAuth
 subjectKeyIdentifier    = hash
 authorityKeyIdentifier  = keyid, issuer:always
 
 [ req_client_x509_extensions ]
 basicConstraints = CA:false
 keyUsage = digitalSignature, keyEncipherment
-extendedKeyUsage = serverAuth, clientAuth
+extendedKeyUsage = clientAuth
 subjectKeyIdentifier    = hash
 authorityKeyIdentifier  = keyid, issuer:always
 #===========================================================================
@@ -407,7 +407,7 @@ req_extensions          = v3_req
 [ req_server_x509_extensions ]
 basicConstraints = CA:false
 keyUsage = digitalSignature, keyEncipherment
-extendedKeyUsage = serverAuth, clientAuth
+extendedKeyUsage = serverAuth
 subjectKeyIdentifier    = hash
 authorityKeyIdentifier  = keyid, issuer:always
 

--- a/katello_certs_tools/sslToolConfig.py
+++ b/katello_certs_tools/sslToolConfig.py
@@ -369,7 +369,6 @@ x509_extensions         = req_ca_x509_extensions
 basicConstraints = CA:true
 keyUsage = digitalSignature, keyEncipherment, keyCertSign, cRLSign
 extendedKeyUsage = serverAuth, clientAuth
-nsCertType = server, sslCA
 subjectKeyIdentifier    = hash
 authorityKeyIdentifier  = keyid, issuer:always
 
@@ -377,7 +376,6 @@ authorityKeyIdentifier  = keyid, issuer:always
 basicConstraints = CA:false
 keyUsage = digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth, clientAuth
-nsCertType = server
 subjectKeyIdentifier    = hash
 authorityKeyIdentifier  = keyid, issuer:always
 
@@ -385,7 +383,6 @@ authorityKeyIdentifier  = keyid, issuer:always
 basicConstraints = CA:false
 keyUsage = digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth, clientAuth
-nsCertType = client
 subjectKeyIdentifier    = hash
 authorityKeyIdentifier  = keyid, issuer:always
 #===========================================================================
@@ -411,7 +408,6 @@ req_extensions          = v3_req
 basicConstraints = CA:false
 keyUsage = digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth, clientAuth
-nsCertType = %s
 subjectKeyIdentifier    = hash
 authorityKeyIdentifier  = keyid, issuer:always
 
@@ -709,7 +705,7 @@ serial                  = $dir/serial
               )
         else:
             openssl_cnf = CONF_TEMPLATE_SERVER \
-              % (gen_req_distinguished_name(rdn), d['--purpose'],  gen_req_alt_names(d, rdn['CN']))
+              % (gen_req_distinguished_name(rdn), gen_req_alt_names(d, rdn['CN']))
 
         try:
             rotated = rotateFile(filepath=self.filename, verbosity=verbosity)

--- a/katello_certs_tools/sslToolConfig.py
+++ b/katello_certs_tools/sslToolConfig.py
@@ -370,8 +370,6 @@ basicConstraints = CA:true
 keyUsage = digitalSignature, keyEncipherment, keyCertSign, cRLSign
 extendedKeyUsage = serverAuth, clientAuth
 nsCertType = server, sslCA
-# PKIX recommendations harmless if included in all certificates.
-nsComment               = "Katello SSL Tool Generated Certificate"
 subjectKeyIdentifier    = hash
 authorityKeyIdentifier  = keyid, issuer:always
 
@@ -380,8 +378,6 @@ basicConstraints = CA:false
 keyUsage = digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth, clientAuth
 nsCertType = server
-# PKIX recommendations harmless if included in all certificates.
-nsComment               = "Katello SSL Tool Generated Certificate"
 subjectKeyIdentifier    = hash
 authorityKeyIdentifier  = keyid, issuer:always
 
@@ -390,8 +386,6 @@ basicConstraints = CA:false
 keyUsage = digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth, clientAuth
 nsCertType = client
-# PKIX recommendations harmless if included in all certificates.
-nsComment               = "Katello SSL Tool Generated Certificate"
 subjectKeyIdentifier    = hash
 authorityKeyIdentifier  = keyid, issuer:always
 #===========================================================================
@@ -418,8 +412,6 @@ basicConstraints = CA:false
 keyUsage = digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth, clientAuth
 nsCertType = %s
-# PKIX recommendations harmless if included in all certificates.
-nsComment               = "Katello SSL Tool Generated Certificate, got it?"
 subjectKeyIdentifier    = hash
 authorityKeyIdentifier  = keyid, issuer:always
 

--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,7 @@ PYTHON=python3
 
 if [[ -f /etc/redhat-release ]]; then
   . /etc/os-release
-  if [[ $VERSION_ID == 8 ]] ; then
+  if [[ $VERSION_ID == "8.10" ]] ; then
     REPOS="--enablerepo=powertools"
   else
     REPOS=""


### PR DESCRIPTION
See https://docs.openssl.org/1.1.1/man5/x509v3_config/#deprecated-extensions for the noted deprecations being removed.

The code was also correctly setting `nsCertType` to the right purpose, but failing to match this with `extendedKeyUsage`. This fixes that inconsistency.