### PR TITLE
Enable crb repo for docbook-utils on EL9 in CI

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -10,6 +10,8 @@ if [[ -f /etc/redhat-release ]]; then
   . /etc/os-release
   if [[ $VERSION_ID == 8* ]] ; then
     REPOS="--enablerepo=powertools"
+  elif [[ $VERSION_ID == 9* ]] ; then
+    REPOS="--enablerepo=crb"
   else
     REPOS=""
   fi


### PR DESCRIPTION
## Summary

- CentOS Stream 9 renamed EL8's `powertools` repo to `crb`
- `test.sh` only special-cased `VERSION_ID == 8*`, so on EL9 `docbook-utils` (which lives in `crb`) fails to resolve and `dnf install` aborts before any test runs — this is why the `centos (stream9)` CI job has been failing
- Add an `elif` branch enabling `crb` for `VERSION_ID == 9*`

## Test plan

- [x] Verified on a test PR against my own fork: `centos (stream9)` job passes (previously failed with `No match for argument: docbook-utils`)
- [x] `almalinux (8)` and `lint` jobs remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
